### PR TITLE
Catwalks 4: neo-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,15 @@
-# Welcome to Catwalks 4
+# Welcome to Catwalks 4.1
 
-This mod is a direct port of the original Catwalks 3 mod.
-If you'd like to see the original, please click here [Catwalks3](https://github.com/thecodewarrior/Catwalks3/tree/1.12)
+## This mod is a direct port or bulkhead of the original Catwalks 3 and 4 mod <br/> If you'd like to see the original, please see the main repo or click here [Catwalks3](https://github.com/thecodewarrior/Catwalks3/tree/1.12)
 
-I'd like to thank [thecodewarrior](https://github.com/thecodewarrior) for the original three versions of the mod as well as the base code for the 1.12 version
+We'd like to thank [thecodewarrior](https://github.com/thecodewarrior) for the original three versions of the mod as well as the base code for the 1.12 version
 
-I'd also like to thank the original modeller, winddelay, for his amazing models. Seriously, we ported this solely because the models are great.
+We'd also like to thank the original modeller, winddelay, for his amazing models. Seriously, we ported this solely because the models are great.
+---
+And also I'd so like to thank them all for the good ground for `Nevermindland`
+---
 
+It was not supposed as a truly continuation or extension of the original series <br/>
+Just enough large bugfix for one far too long abandoned mod
 
-## So what can you expect us to add into the mod?
-
-- [x] Basic Catwalks
-- [x] Support Cables
-- [ ] Catwalk Stairs
-- [ ] Catwalk Ladders
-
-## What might we plan for later?
-
-- [ ] Immersive Engineering Catwalks
-- [ ] Immersive Engineering Light/Lamp Support
-- [ ] Catwalk Doors
-- [ ] Catwalk Cages
+### *Was prepared for [`Nevermindland`-server](https://discord.gg/jjTd5jdcM5)*

--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ And also I'd so like to thank them all for the good ground for `Nevermindland`
 It was not supposed as a truly continuation or extension of the original series <br/>
 Just enough large bugfix for one far too long abandoned mod
 
-### *Was prepared for [`Nevermindland`-server](https://discord.gg/jjTd5jdcM5)*
+|<img width="400" alt="Nevermindland got catwalks" src="https://github.com/user-attachments/assets/cb7b1748-6774-4d32-a336-eb04ed1d748d" />|
+| :---: |
+| *Was prepared for [`Nevermindland`-server](https://discord.gg/jjTd5jdcM5)* |

--- a/src/main/java/dmfmm/catwalks/block/CableBlock.java
+++ b/src/main/java/dmfmm/catwalks/block/CableBlock.java
@@ -1,11 +1,16 @@
 package dmfmm.catwalks.block;
 
 import dmfmm.catwalks.registry.BlockRegistry;
+import dmfmm.catwalks.registry.ItemRegistry;
 import net.minecraft.block.Block;
+import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -15,60 +20,157 @@ import net.minecraftforge.common.property.IExtendedBlockState;
 import net.minecraftforge.common.property.IUnlistedProperty;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 
 
 public class CableBlock extends GenericBlock {
 
+    public enum CableFacing implements IStringSerializable {
+        EAST, WEST, NORTH, SOUTH, NONE;
 
+        @Override
+        public String getName() {
+            return this.name().toLowerCase();
+        }
 
+        public EnumFacing toEnumFacing() {
+            switch (this) {
+                case EAST:  return EnumFacing.EAST;
+                case WEST:  return EnumFacing.WEST;
+                case NORTH: return EnumFacing.NORTH;
+                case SOUTH: return EnumFacing.SOUTH;
+                default:    return null;
+            }
+        }
+
+        public static CableFacing fromEnumFacing(EnumFacing f) {
+            switch (f) {
+                case EAST:  return EAST;
+                case WEST:  return WEST;
+                case NORTH: return NORTH;
+                case SOUTH: return SOUTH;
+                default:    return NONE;
+            }
+        }
+    }
+
+    public static final PropertyEnum<CableFacing> PREFERRED_FACING =
+            PropertyEnum.create("preferred_facing", CableFacing.class);
+    private static final CableFacing[] CYCLE = {
+            CableFacing.EAST, CableFacing.WEST, CableFacing.NORTH, CableFacing.SOUTH, CableFacing.NONE
+    };
+    private static final EnumFacing[] HORIZONTALS = {
+            EnumFacing.EAST, EnumFacing.WEST, EnumFacing.NORTH, EnumFacing.SOUTH
+    };
 
     public CableBlock() {
         super("cable");
-
+        this.setDefaultState(this.blockState.getBaseState()
+                .withProperty(PREFERRED_FACING, CableFacing.EAST));
     }
 
+    @Override
+    public boolean onBlockActivated(World world, BlockPos pos, IBlockState state,
+                                    EntityPlayer player, EnumHand hand,
+                                    EnumFacing facing, float hitX, float hitY, float hitZ) {
+        ItemStack held = player.getHeldItem(hand);
+        if (held.getItem() != ItemRegistry.BLOW_TORCH) {
+            return false;
+        }
+        List<CableFacing> validFacings = new ArrayList<>();
+        for (EnumFacing dir : HORIZONTALS) {
+            if (world.getBlockState(pos.offset(dir)).getBlock() == BlockRegistry.CATWALK) {
+                validFacings.add(CableFacing.fromEnumFacing(dir));
+            }
+        }
+        validFacings.add(CableFacing.NONE);
+
+        if (validFacings.size() < 2) {
+            return false;
+        }
+
+        if (!world.isRemote) {
+            CableFacing current = state.getValue(PREFERRED_FACING);
+            int idx = validFacings.indexOf(current);
+            CableFacing next;
+            if (idx == -1) {
+                next = validFacings.get(0);
+            } else {
+                next = validFacings.get((idx + 1) % validFacings.size());
+            }
+            world.setBlockState(pos, state.withProperty(PREFERRED_FACING, next), 3);
+        }
+        return true;
+    }
+
+    @Override
     public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos)
     {
-        if(state instanceof IExtendedBlockState) {
-            boolean matchup = world.getBlockState(pos.up()).getBlock() == this;
+        if (state instanceof IExtendedBlockState) {
+            boolean matchup   = world.getBlockState(pos.up()).getBlock() == this;
             boolean matchdown = world.getBlockState(pos.down()).getBlock() == this;
 
             IExtendedBlockState theState = (IExtendedBlockState) state;
 
-            if(matchup && matchdown) {
+            if (matchup && matchdown) {
                 theState = theState.withProperty(STATE, CableState.MIDDLE);
-            } else if(matchup) {
+            } else if (matchup) {
                 theState = theState.withProperty(STATE, CableState.BOTTOM);
             } else {
                 theState = theState.withProperty(STATE, CableState.TOP);
             }
 
-            IBlockState east = world.getBlockState(pos.east());
-            IBlockState west = world.getBlockState(pos.west());
-            IBlockState north = world.getBlockState(pos.north());
-            IBlockState south = world.getBlockState(pos.south());
-            Block toCheck = BlockRegistry.CATWALK;
+            CableFacing preferred = state.getValue(PREFERRED_FACING);
 
-            if(east.getBlock() == toCheck) {
-                theState = theState.withProperty(FACING, EnumFacing.EAST);
-                theState = theState.withProperty(CONNECTED, true);
-            } else if(west.getBlock() == toCheck){
-                theState = theState.withProperty(FACING, EnumFacing.WEST);
-                theState = theState.withProperty(CONNECTED, true);
-            } else if(north.getBlock() == toCheck){
-                theState = theState.withProperty(FACING, EnumFacing.NORTH);
-                theState = theState.withProperty(CONNECTED, true);
-            } else if(south.getBlock() == toCheck){
-                theState = theState.withProperty(FACING, EnumFacing.SOUTH);
-                theState = theState.withProperty(CONNECTED, true);
-            } else {
+            if (preferred == CableFacing.NONE) {
                 theState = theState.withProperty(CONNECTED, false);
+                return theState;
             }
+
+            EnumFacing preferredDir = preferred.toEnumFacing();
+            if (world.getBlockState(pos.offset(preferredDir)).getBlock() == BlockRegistry.CATWALK) {
+                theState = theState.withProperty(FACING, preferredDir);
+                theState = theState.withProperty(CONNECTED, true);
+                return theState;
+            }
+
+            for (EnumFacing dir : HORIZONTALS) {
+                if (world.getBlockState(pos.offset(dir)).getBlock() == BlockRegistry.CATWALK) {
+                    theState = theState.withProperty(FACING, dir);
+                    theState = theState.withProperty(CONNECTED, true);
+                    return theState;
+                }
+            }
+
+            theState = theState.withProperty(CONNECTED, false);
             return theState;
         }
 
         return state;
+    }
+
+    @Override
+    public int getMetaFromState(IBlockState state) {
+        switch (state.getValue(PREFERRED_FACING)) {
+            case EAST:  return 0;
+            case WEST:  return 1;
+            case NORTH: return 2;
+            case SOUTH: return 3;
+            case NONE:  return 4;
+            default:    return 0;
+        }
+    }
+
+    @Override
+    public IBlockState getStateFromMeta(int meta) {
+        switch (meta) {
+            case 1:  return getDefaultState().withProperty(PREFERRED_FACING, CableFacing.WEST);
+            case 2:  return getDefaultState().withProperty(PREFERRED_FACING, CableFacing.NORTH);
+            case 3:  return getDefaultState().withProperty(PREFERRED_FACING, CableFacing.SOUTH);
+            case 4:  return getDefaultState().withProperty(PREFERRED_FACING, CableFacing.NONE);
+            default: return getDefaultState().withProperty(PREFERRED_FACING, CableFacing.EAST);
+        }
     }
 
     @Deprecated
@@ -77,28 +179,22 @@ public class CableBlock extends GenericBlock {
         addCollisionBoxToList(pos, entityBox, collidingBoxes, this.getBoundingBox(state, worldIn, pos));
     }
 
-
-    public static final AxisAlignedBB CABLE_BOX = new AxisAlignedBB(0.44, 0, 0.44, 0.56, 1, 0.56);
+    public static final AxisAlignedBB CABLE_BOX            = new AxisAlignedBB(0.44, 0, 0.44, 0.56, 1, 0.56);
     public static final AxisAlignedBB CLIP_BOX_NORTH_SOUTH = new AxisAlignedBB(0.23, 0, 0, 0.75, 0.13, 0.59);
-    public static final AxisAlignedBB CLIP_BOX_EAST_WEST = new AxisAlignedBB(0, 0, 0.23, 0.59, 0.13, 0.75);
+    public static final AxisAlignedBB CLIP_BOX_EAST_WEST   = new AxisAlignedBB(0, 0, 0.23, 0.59, 0.13, 0.75);
 
     @Deprecated
     public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos)
     {
         IBlockState estate = this.getExtendedState(state, source, pos);
-        if(estate instanceof IExtendedBlockState){
+        if (estate instanceof IExtendedBlockState) {
             IExtendedBlockState estater = (IExtendedBlockState) estate;
-            if(estater.getValue(CONNECTED)){
-                switch (estater.getValue(FACING)){
-                    case NORTH:
-                        return CABLE_BOX.union(CLIP_BOX_NORTH_SOUTH);
-                    case SOUTH:
-                        return CABLE_BOX.union(CLIP_BOX_NORTH_SOUTH).offset(0, 0, 0.4);
-                    case EAST:
-                        return CABLE_BOX.union(CLIP_BOX_EAST_WEST).offset(0.4, 0, 0);
-                    case WEST:
-                        return CABLE_BOX.union(CLIP_BOX_EAST_WEST);
-
+            if (estater.getValue(CONNECTED)) {
+                switch (estater.getValue(FACING)) {
+                    case NORTH: return CABLE_BOX.union(CLIP_BOX_NORTH_SOUTH);
+                    case SOUTH: return CABLE_BOX.union(CLIP_BOX_NORTH_SOUTH).offset(0, 0, 0.4);
+                    case EAST:  return CABLE_BOX.union(CLIP_BOX_EAST_WEST).offset(0.4, 0, 0);
+                    case WEST:  return CABLE_BOX.union(CLIP_BOX_EAST_WEST);
                 }
             } else {
                 return CABLE_BOX;
@@ -108,28 +204,22 @@ public class CableBlock extends GenericBlock {
     }
 
     @Override
-    public boolean isOpaqueCube(IBlockState state) {
-        return false;
-    }
+    public boolean isOpaqueCube(IBlockState state) { return false; }
 
-    public boolean isNormalCube(IBlockState state, IBlockAccess world, BlockPos pos)
-    {
-        return false;
-    }
+    public boolean isNormalCube(IBlockState state, IBlockAccess world, BlockPos pos) { return false; }
 
     @Deprecated
-    public boolean isFullCube(IBlockState state)
-    {
-        return false;
-    }
+    public boolean isFullCube(IBlockState state) { return false; }
 
     @Override
     public BlockStateContainer createBlockState() {
-        return new BlockStateContainer.Builder(this).add(CONNECTED).add(FACING).add(STATE).build();
+        return new BlockStateContainer.Builder(this)
+                .add(PREFERRED_FACING)
+                .add(CONNECTED).add(FACING).add(STATE)
+                .build();
     }
 
-
-    public static enum CableState implements IStringSerializable {
+    public enum CableState implements IStringSerializable {
         TOP, MIDDLE, BOTTOM;
 
         @Override
@@ -139,70 +229,23 @@ public class CableBlock extends GenericBlock {
     }
 
     public static final IUnlistedProperty<CableState> STATE = new IUnlistedProperty<CableState>() {
-
-        @Override
-        public String getName() {
-            return "cablestate";
-        }
-
-        @Override
-        public boolean isValid(CableState value) {
-            return true;
-        }
-
-        @Override
-        public Class<CableState> getType() {
-            return CableState.class;
-        }
-
-        @Override
-        public String valueToString(CableState value) {
-            return value.toString().toLowerCase();
-        }
+        @Override public String getName() { return "cablestate"; }
+        @Override public boolean isValid(CableState value) { return true; }
+        @Override public Class<CableState> getType() { return CableState.class; }
+        @Override public String valueToString(CableState value) { return value.toString().toLowerCase(); }
     };
 
     public static final IUnlistedProperty<Boolean> CONNECTED = new IUnlistedProperty<Boolean>() {
-
-        @Override
-        public String getName() {
-            return "connected";
-        }
-
-        @Override
-        public boolean isValid(Boolean value) {
-            return true;
-        }
-
-        @Override
-        public Class<Boolean> getType() {
-            return Boolean.class;
-        }
-
-        @Override
-        public String valueToString(Boolean value) {
-            return value ? "true" : "false";
-        }
+        @Override public String getName() { return "connected"; }
+        @Override public boolean isValid(Boolean value) { return true; }
+        @Override public Class<Boolean> getType() { return Boolean.class; }
+        @Override public String valueToString(Boolean value) { return value ? "true" : "false"; }
     };
 
     public static final IUnlistedProperty<EnumFacing> FACING = new IUnlistedProperty<EnumFacing>() {
-        @Override
-        public String getName() {
-            return "direction";
-        }
-
-        @Override
-        public boolean isValid(EnumFacing value) {
-            return value != EnumFacing.UP && value != EnumFacing.DOWN;
-        }
-
-        @Override
-        public Class<EnumFacing> getType() {
-            return EnumFacing.class;
-        }
-
-        @Override
-        public String valueToString(EnumFacing value) {
-            return value.toString().toLowerCase();
-        }
+        @Override public String getName() { return "direction"; }
+        @Override public boolean isValid(EnumFacing value) { return value != EnumFacing.UP && value != EnumFacing.DOWN; }
+        @Override public Class<EnumFacing> getType() { return EnumFacing.class; }
+        @Override public String valueToString(EnumFacing value) { return value.toString().toLowerCase(); }
     };
 }

--- a/src/main/java/dmfmm/catwalks/block/CatwalkBlock.java
+++ b/src/main/java/dmfmm/catwalks/block/CatwalkBlock.java
@@ -41,8 +41,6 @@ import java.util.*;
 
 public class CatwalkBlock extends GenericBlock implements ITileEntityProvider, ICustomItemBlock {
 
-    //public static UnlistedArbitraryProperty CATWALK_STATE = new UnlistedArbitraryProperty("state", CatwalkState.class);
-
     public static final IUnlistedProperty<CatwalkState> CATWALK_STATE  = new IUnlistedProperty<CatwalkState>() {
 
         @Override
@@ -104,7 +102,12 @@ public class CatwalkBlock extends GenericBlock implements ITileEntityProvider, I
     @SuppressWarnings("deprecation")
     public RayTraceResult collisionRayTrace(IBlockState blockState, World worldIn, BlockPos pos, Vec3d start, Vec3d end)
     {
-        CatwalkTile tile = worldIn.getTileEntity(pos) instanceof CatwalkTile ? (CatwalkTile) worldIn.getTileEntity(pos) : null;
+        TileEntity te = worldIn.getTileEntity(pos);
+        if (!(te instanceof CatwalkTile)) {
+            return super.collisionRayTrace(blockState, worldIn, pos, start, end);
+        }
+        CatwalkTile tile = (CatwalkTile) te;
+
         Map<Pair<EnumFacing, AxisAlignedBB>, RayTraceResult> map = new HashMap<>();
         for (Map.Entry<EnumFacing, Pair<AxisAlignedBB, AxisAlignedBB>> it: boundingBoxes.entrySet()) {
             boolean has = tile.has(it.getKey());
@@ -147,6 +150,8 @@ public class CatwalkBlock extends GenericBlock implements ITileEntityProvider, I
                 if(other instanceof CatwalkTile) {
                     ((CatwalkTile) other).updateSide(facing.getOpposite(), false);
                     tile.updateSide(facing, false);
+                    IBlockState neighborState = world.getBlockState(pos.offset(facing));
+                    world.notifyBlockUpdate(pos.offset(facing), neighborState, neighborState, 3);
                 }
                 if(other instanceof IConnectTile) {
                     tile.updateSide(facing, false);
@@ -164,6 +169,9 @@ public class CatwalkBlock extends GenericBlock implements ITileEntityProvider, I
             TileEntity other = world.getTileEntity(pos.offset(facing));
             if(other instanceof CatwalkTile) {
                 ((CatwalkTile) other).updateSide(facing.getOpposite(), true);
+                // Notify neighbors so they re-render with the restored rail side
+                IBlockState neighborState = world.getBlockState(pos.offset(facing));
+                world.notifyBlockUpdate(pos.offset(facing), neighborState, neighborState, 3);
             }
         }
     }
@@ -269,16 +277,18 @@ public class CatwalkBlock extends GenericBlock implements ITileEntityProvider, I
         return false;
     }
 
-    private AxisAlignedBB bounds = FULL_BLOCK_AABB;
+    @SideOnly(Side.CLIENT)
+    private static final ThreadLocal<AxisAlignedBB> lastTracedBounds = ThreadLocal.withInitial(() -> FULL_BLOCK_AABB);
+
     @Override
     public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos)
     {
-        return bounds.setMaxY(1);
+        return FULL_BLOCK_AABB;
     }
 
     @SideOnly(Side.CLIENT)
     private void updateBounds(AxisAlignedBB bb){
-        bounds = bb;
+        lastTracedBounds.set(bb);
     }
 
     @Override

--- a/src/main/java/dmfmm/catwalks/block/LadderBlock.java
+++ b/src/main/java/dmfmm/catwalks/block/LadderBlock.java
@@ -63,7 +63,10 @@ public class LadderBlock extends GenericBlock implements ITileEntityProvider{
             if(f == EnumFacing.UP || f == EnumFacing.DOWN){
                 f = EnumFacing.NORTH;
                 if(world.getBlockState(pos.down()).getBlock() == this){
-                    f = ((LadderTile)world.getTileEntity(pos.down())).getFacing();
+                    TileEntity below = world.getTileEntity(pos.down());
+                    if (below instanceof LadderTile) {
+                        f = ((LadderTile) below).getFacing();
+                    }
                 }
             }
             ((LadderTile) te).setFacing(f);
@@ -92,7 +95,8 @@ public class LadderBlock extends GenericBlock implements ITileEntityProvider{
                 theState = theState.withProperty(STATE, LadderState.MIDDLE);
             } else if(matchup) {
                 theState = theState.withProperty(STATE, LadderState.BOTTOM);
-                TileEntity tes = world.getTileEntity(pos.offset(EnumFacing.NORTH.getOpposite()));
+                EnumFacing tileActualFacing = (te instanceof LadderTile) ? ((LadderTile) te).getFacing() : EnumFacing.NORTH;
+                TileEntity tes = world.getTileEntity(pos.offset(tileActualFacing));
                 if(tes instanceof IConnectTile && !(tes instanceof LadderTile)){
                     theState = theState.withProperty(CONNECTED, true);
                 } else {
@@ -136,8 +140,6 @@ public class LadderBlock extends GenericBlock implements ITileEntityProvider{
         IExtendedBlockState estate = (IExtendedBlockState) this.getExtendedState(state, world, pos);
         Double[][] hit = LadderBlockHitboxes.getBoxAdditions(estate.getValue(FACING));
         AxisAlignedBB bb = new AxisAlignedBB(pos.getX() + hit[1][0], pos.getY() + hit[1][1], pos.getZ() + hit[1][2], pos.getX() + hit[1][3], pos.getY() + hit[1][4], pos.getZ() + hit[1][5]);
-
-        //side panels
         if(
             estate.getValue(STATE) == LadderState.BOTTOM ||
             (estate.getValue(STATE) == LadderState.TOP && estate.getUnlistedNames().contains(HAS_CAGE) && estate.getValue(HAS_CAGE)) ||
@@ -151,7 +153,6 @@ public class LadderBlock extends GenericBlock implements ITileEntityProvider{
                 collidingBoxes.add(bb);
             }
         }
-        //ladderblock
         if(estate.getValue(STATE) == LadderState.BOTTOM || estate.getValue(STATE) == LadderState.MIDDLE || (estate.getValue(STATE) == LadderState.TOP && estate.getUnlistedNames().contains(STATE) && !estate.getValue(CONNECTED))){
             bb = new AxisAlignedBB(pos.getX() + hit[0][0], pos.getY() + hit[0][1], pos.getZ() + hit[0][2], pos.getX() + hit[0][3], pos.getY() + hit[0][4], pos.getZ() + hit[0][5]);
             if (bb.intersects(entityBox)) {
@@ -159,7 +160,6 @@ public class LadderBlock extends GenericBlock implements ITileEntityProvider{
             }
         }
 
-        //cage box
         if((estate.getValue(STATE) == LadderState.TOP && estate.getUnlistedNames().contains(HAS_CAGE) && estate.getValue(HAS_CAGE)) || (estate.getValue(STATE) == LadderState.MIDDLE && estate.getUnlistedNames().contains(HAS_CAGE) && estate.getValue(HAS_CAGE))){
             bb = new AxisAlignedBB(pos.getX() + hit[3][0], pos.getY() + hit[3][1], pos.getZ() + hit[3][2], pos.getX() + hit[3][3], pos.getY() + hit[3][4], pos.getZ() + hit[3][5]);
             if (bb.intersects(entityBox)) {
@@ -167,7 +167,6 @@ public class LadderBlock extends GenericBlock implements ITileEntityProvider{
             }
         }
 
-        //Base colision
         if(estate.getValue(STATE) == LadderState.BOTTOM){
             bb = new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX()+ 1, pos.getY()+ 0.2, pos.getZ()+1);
             if (bb.intersects(entityBox)) {

--- a/src/main/java/dmfmm/catwalks/block/StairBlock.java
+++ b/src/main/java/dmfmm/catwalks/block/StairBlock.java
@@ -1,7 +1,5 @@
 package dmfmm.catwalks.block;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockStairs;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyDirection;
 import net.minecraft.block.state.BlockStateContainer;
@@ -27,8 +25,6 @@ public class StairBlock extends GenericBlock {
     public static class State {
         public int up = 0, down = 0;
         public boolean left = false, right = false;
-
-        // facing is stored on blockstate visible
 
         @Override
         public int hashCode() {
@@ -91,17 +87,14 @@ public class StairBlock extends GenericBlock {
         if (state instanceof IExtendedBlockState) {
             IExtendedBlockState estate = (IExtendedBlockState) state;
             State statey = new State();
-            // todo: me
-            estate.withProperty(STATE, statey);
-            return estate;
+            return estate.withProperty(STATE, statey);
         }
         else {
             return state;
         }
     }
-
     @Override
-    public BlockStateContainer getBlockState() {
+    public BlockStateContainer createBlockState() {
         return new BlockStateContainer.Builder(this).add(FACING).add(STATE).build();
     }
 

--- a/src/main/java/dmfmm/catwalks/client/CableModel.java
+++ b/src/main/java/dmfmm/catwalks/client/CableModel.java
@@ -53,7 +53,10 @@ public class CableModel implements IBakedModel {
 
              CableBlock.CableState state_the_cramp = ext.getValue(CableBlock.STATE);
              if (ext.getValue(CableBlock.CONNECTED)) {
-                 List<BakedQuad> q = this.cable_rotated.getOrDefault(ext.getValue(CableBlock.FACING), this.cable_none).getQuads(state, side, rand);
+                 // BUG FIX #10: IBakedModel.getQuads() can return an immutable list (e.g. ImmutableList
+                 // from Guava-backed baked models). Calling addAll() on it throws UnsupportedOperationException.
+                 // Always copy into a new mutable ArrayList before mutating.
+                 List<BakedQuad> q = new java.util.ArrayList<>(this.cable_rotated.getOrDefault(ext.getValue(CableBlock.FACING), this.cable_none).getQuads(state, side, rand));
                  q.addAll(this.cable_bottom.getQuads(state, side, rand));
                  return q;
              }

--- a/src/main/java/dmfmm/catwalks/client/CableModel.java
+++ b/src/main/java/dmfmm/catwalks/client/CableModel.java
@@ -53,9 +53,6 @@ public class CableModel implements IBakedModel {
 
              CableBlock.CableState state_the_cramp = ext.getValue(CableBlock.STATE);
              if (ext.getValue(CableBlock.CONNECTED)) {
-                 // BUG FIX #10: IBakedModel.getQuads() can return an immutable list (e.g. ImmutableList
-                 // from Guava-backed baked models). Calling addAll() on it throws UnsupportedOperationException.
-                 // Always copy into a new mutable ArrayList before mutating.
                  List<BakedQuad> q = new java.util.ArrayList<>(this.cable_rotated.getOrDefault(ext.getValue(CableBlock.FACING), this.cable_none).getQuads(state, side, rand));
                  q.addAll(this.cable_bottom.getQuads(state, side, rand));
                  return q;

--- a/src/main/java/dmfmm/catwalks/client/RedOverlayEvent.java
+++ b/src/main/java/dmfmm/catwalks/client/RedOverlayEvent.java
@@ -128,7 +128,10 @@ public class RedOverlayEvent {
         GlStateManager.translate(-doubleX, -doubleY, -doubleZ);
 
 
-        GlStateManager.colorMask(false, true, true, true);
+        // BUG FIX #16: colorMask(false, true, true, true) writes GREEN and BLUE but suppresses RED.
+        // This produced a cyan tint on missing faces, not the intended red overlay.
+        // Correct mask writes only to the RED channel, creating the actual red highlight.
+        GlStateManager.colorMask(true, false, false, true);
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder buffer = tessellator.getBuffer();
         buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);

--- a/src/main/java/dmfmm/catwalks/client/RedOverlayEvent.java
+++ b/src/main/java/dmfmm/catwalks/client/RedOverlayEvent.java
@@ -127,10 +127,6 @@ public class RedOverlayEvent {
         GlStateManager.pushMatrix();
         GlStateManager.translate(-doubleX, -doubleY, -doubleZ);
 
-
-        // BUG FIX #16: colorMask(false, true, true, true) writes GREEN and BLUE but suppresses RED.
-        // This produced a cyan tint on missing faces, not the intended red overlay.
-        // Correct mask writes only to the RED channel, creating the actual red highlight.
         GlStateManager.colorMask(true, false, false, true);
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder buffer = tessellator.getBuffer();

--- a/src/main/java/dmfmm/catwalks/client/catwalks/CatwalkModel.java
+++ b/src/main/java/dmfmm/catwalks/client/catwalks/CatwalkModel.java
@@ -1,6 +1,7 @@
 package dmfmm.catwalks.client.catwalks;
 
 import com.google.common.collect.ImmutableList;
+import dmfmm.catwalks.Catwalks;
 import dmfmm.catwalks.block.CatwalkBlock;
 import dmfmm.catwalks.utils.CatwalkConfigs;
 import net.minecraft.block.state.IBlockState;
@@ -11,17 +12,27 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.Vec3d;
+import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.common.property.IExtendedBlockState;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Function;
 
+@Mod.EventBusSubscriber(modid = Catwalks.MODID, value = Side.CLIENT)
 public class CatwalkModel implements IBakedModel{
 
     IBakedModel item, rails, floor;
     //static Map<CatwalkState, List<BakedQuad>> cache = new HashMap<>();
     static Map<String, Map<CatwalkState, List<BakedQuad>>> cache2 = new HashMap<>();
+
+    @SubscribeEvent
+    public static void onModelBake(ModelBakeEvent event) {
+        cache2.clear();
+    }
 
     public CatwalkModel(IBakedModel item, IBakedModel rails, IBakedModel floor) {
         this.item = item;
@@ -43,18 +54,16 @@ public class CatwalkModel implements IBakedModel{
             cw = new CatwalkState(RailSection.OUTER, RailSection.OUTER, RailSection.OUTER, RailSection.OUTER,
                                   FloorSection.OUTER, FloorSection.OUTER, FloorSection.OUTER, FloorSection.OUTER, 0);
         }
+        if (!cache2.containsKey(material)) {
+            cache2.put(material, new HashMap<>());
+        }
+        Map<CatwalkState, List<BakedQuad>> materialCache = cache2.get(material);
 
-        if(cache2.containsKey(material) && !CatwalkConfigs.supportOptifine){
-            Map<CatwalkState, List<BakedQuad>> map = cache2.get(material);
-            if(map.containsKey(cw)){
-                List<BakedQuad> quads = map.get(cw);
-                if(!quads.isEmpty()) {
-                    return map.get(cw);
-                }
+        if (!CatwalkConfigs.supportOptifine) {
+            if (materialCache.containsKey(cw)) {
+                List<BakedQuad> cached = materialCache.get(cw);
+                if (!cached.isEmpty()) return cached;
             }
-        } else {
-            Map<CatwalkState, List<BakedQuad>> m = new HashMap<>();
-            cache2.put(material, m);
         }
         //if(cache.containsKey(cw)){
         //    return cache.get(cw);
@@ -73,8 +82,12 @@ public class CatwalkModel implements IBakedModel{
                 if (cw.floorSections.get(it) == null) continue;
                 ModelSlicer.sliceInto(builder, floorQuads, cw.floorSections.get(it).boundingBoxes.get(it), offset, filter);
             }
-            cache2.get(material).put(cw, builder.build());
-            return cache2.get(material).get(cw);
+            if (!CatwalkConfigs.supportOptifine) {
+                materialCache.put(cw, builder.build());
+                return materialCache.get(cw);
+            } else {
+                return builder.build();
+            }
 
             /*cache.put(cw, builder.build());
             return cache.get(cw);*/

--- a/src/main/java/dmfmm/catwalks/client/catwalks/CatwalkState.java
+++ b/src/main/java/dmfmm/catwalks/client/catwalks/CatwalkState.java
@@ -35,12 +35,12 @@ public class CatwalkState {
 
     @Override
     public boolean equals(Object o) {
-        if(this.hashCode() == o.hashCode()) return true;
+        if (this == o) return true;
         if(!(o instanceof CatwalkState)) return false;
-
-        if(railSections != ((CatwalkState) o).railSections) return false;
-        if(floorSections != ((CatwalkState) o).floorSections) return false;
-        if(layers != ((CatwalkState) o).layers) return false;
+        CatwalkState other = (CatwalkState) o;
+        if(!railSections.equals(other.railSections)) return false;
+        if(!floorSections.equals(other.floorSections)) return false;
+        if(!layers.equals(other.layers)) return false;
         return true;
     }
 

--- a/src/main/java/dmfmm/catwalks/events/NyanWalkRecipeEvent.java
+++ b/src/main/java/dmfmm/catwalks/events/NyanWalkRecipeEvent.java
@@ -34,15 +34,14 @@ public class NyanWalkRecipeEvent {
                 if(itemStacker.getItem().getItem() instanceof ItemBlockCatwalk){
                     NBTTagCompound tag = itemStacker.getItem().getTagCompound();
                     if(tag != null) {
-                        tag.setString("material", CatwalkMaterial.NYANWALK.getName().toLowerCase());
-                        ItemStack jones = new ItemStack(Item.getItemFromBlock(BlockRegistry.CATWALK), itemStacker.getItem().getCount());
-                        jones.setTagCompound(tag);
-                        EntityItem i = new EntityItem(itemStacker.getEntityWorld(), itemStacker.posX, itemStacker.posY + 8, itemStacker.posZ, jones);
-                        itemStacker.setDead();
-
-                        if(!world.isRemote)
+                        if (!world.isRemote) {
+                            tag.setString("material", CatwalkMaterial.NYANWALK.getName().toLowerCase());
+                            ItemStack jones = new ItemStack(Item.getItemFromBlock(BlockRegistry.CATWALK), itemStacker.getItem().getCount());
+                            jones.setTagCompound(tag);
+                            EntityItem i = new EntityItem(itemStacker.getEntityWorld(), itemStacker.posX, itemStacker.posY + 8, itemStacker.posZ, jones);
+                            itemStacker.setDead();
                             world.spawnEntity(i);
-                        else{
+                        } else {
                             world.spawnParticle(EnumParticleTypes.DRAGON_BREATH, itemStacker.posX, itemStacker.posY, itemStacker.posZ, 0, 1, 0);
 
                             Random random = world.rand;

--- a/src/main/java/dmfmm/catwalks/events/ServerChatAddition.java
+++ b/src/main/java/dmfmm/catwalks/events/ServerChatAddition.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class ServerChatAddition {
 
-    private List<String> coolPeople = Arrays.asList("wolfywing", "gearsgoddx", "AcidAngel");
+    private List<String> coolPeople = Arrays.asList("wolfywing", "gearsgoddx", "AcidAngel", "Fabuur", "zeLOVE4ek", "faburuso");
 
 
     @SubscribeEvent

--- a/src/main/java/dmfmm/catwalks/tileentity/CatwalkStateCalculator.java
+++ b/src/main/java/dmfmm/catwalks/tileentity/CatwalkStateCalculator.java
@@ -3,18 +3,27 @@ package dmfmm.catwalks.tileentity;
 
 import dmfmm.catwalks.client.catwalks.CatwalkModel;
 import dmfmm.catwalks.client.catwalks.CatwalkState;
+import dmfmm.catwalks.Catwalks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
 
 
+@Mod.EventBusSubscriber(modid = Catwalks.MODID)
 public class CatwalkStateCalculator {
 
     static HashMap<World, HashMap<Long, CatwalkTile>> tileCache = new HashMap<>();
+    @SubscribeEvent
+    public static void onWorldUnload(WorldEvent.Unload event) {
+        tileCache.remove(event.getWorld());
+    }
 
     public static void removeFromCache(World world, BlockPos pos){
         if(tileCache.containsKey(world)) {
@@ -39,7 +48,12 @@ public class CatwalkStateCalculator {
         if(tileCache.containsKey(world)){
             HashMap<Long, CatwalkTile> hashMap = tileCache.get(world);
             if(hashMap.containsKey(l)){
-                return hashMap.get(l);
+                CatwalkTile cached = hashMap.get(l);
+                if (cached.isInvalid()) {
+                    hashMap.remove(l);
+                } else {
+                    return cached;
+                }
             }
             TileEntity tileEntity = world.getTileEntity(pos);
             if(tileEntity instanceof CatwalkTile) {
@@ -67,7 +81,9 @@ public class CatwalkStateCalculator {
     }
 
     public boolean has(EnumFacing side, BlockPos pos) {
-        return getCached(pos).has(side);
+        CatwalkTile tile = getCached(pos);
+        if (tile == null) return false;
+        return tile.has(side);
     }
 
     public CatwalkState calculate() {

--- a/src/main/java/dmfmm/catwalks/tileentity/CatwalkTile.java
+++ b/src/main/java/dmfmm/catwalks/tileentity/CatwalkTile.java
@@ -35,7 +35,6 @@ public class CatwalkTile extends TileEntity implements IConnectTile{
         return sides.get(side);
     }
 
-    //@SideOnly(Side.CLIENT)
     public CatwalkState getCatwalkState(){
         return new CatwalkStateCalculator(this.getWorld(), this.getPos()).calculate();
     }
@@ -63,7 +62,7 @@ public class CatwalkTile extends TileEntity implements IConnectTile{
     {
         super.readFromNBT(compound);
         String mat = compound.getString("material");
-        if(mat != "") {
+        if (!mat.isEmpty()) {
             this.material = CatwalkMaterial.valueOf(mat.toUpperCase());
         }
 
@@ -73,15 +72,6 @@ public class CatwalkTile extends TileEntity implements IConnectTile{
     }
 
 
-    /**
-     * Called when you receive a TileEntityData packet for the location this
-     * TileEntity is currently in. On the client, the NetworkManager will always
-     * be the remote server. On the server, it will be whomever is responsible for
-     * sending the packet.
-     *
-     * @param net The NetworkManager the packet originated from
-     * @param pkt The data packet
-     */
     public void onDataPacket(net.minecraft.network.NetworkManager net, net.minecraft.network.play.server.SPacketUpdateTileEntity pkt)
     {
         NBTTagCompound tag = pkt.getNbtCompound();

--- a/src/main/java/dmfmm/catwalks/utils/LadderBlockHitboxes.java
+++ b/src/main/java/dmfmm/catwalks/utils/LadderBlockHitboxes.java
@@ -1,6 +1,6 @@
 package dmfmm.catwalks.utils;
 
-import javafx.util.Pair;
+import dmfmm.catwalks.utils.Pair;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 

--- a/src/main/resources/assets/catwalks/blockstates/cable.json
+++ b/src/main/resources/assets/catwalks/blockstates/cable.json
@@ -5,6 +5,11 @@
   },
   "variants": {
     "normal": [{}],
-    "inventory": [{}]
+    "inventory": [{}],
+    "preferred_facing=east":  [{}],
+    "preferred_facing=west":  [{}],
+    "preferred_facing=north": [{}],
+    "preferred_facing=south": [{}],
+    "preferred_facing=none":  [{}]
   }
 }


### PR DESCRIPTION
# **Catwalks 4**: neo-**fix**

_by faburuso_


## Fixed:

- ### Rails-render issues
<img width="1920" height="1080" alt="invalid rails" src="https://github.com/user-attachments/assets/811626a3-ba55-46f5-a8c7-33f4985be50c" /> <br/>

```diff
- Rails could be removed as hitboxes, but not as rendered parts
+ Rails can be removed correctly at all
```

- ### Texture issues after resource-reloading
<img width="1920" height="1080" alt="invalid textures" src="https://github.com/user-attachments/assets/2bbdb536-63d1-4aed-9fef-d542a303814d" /> <br/>

```diff
- After changes of shaderpacks/resourcepacks/etc the main textures of catwalks could be broken
+ Correct resource-reloading with the valid textures
```

- ### Crashes' fix
```diff
- Random `<NullPointerException>` caused by cables connected to catwalks
+ Correct handling the connected cables
```


## Added features:

- ### Cables' connections turning

| Connections |
| :---: |
| <img width="1920" height="1080" alt="Connection right" src="https://github.com/user-attachments/assets/0c9bcc74-d6e8-4ae9-bd2a-ac530a1fd900" /> |
| <img width="1920" height="1080" alt="Connection up" src="https://github.com/user-attachments/assets/f820fa1d-d98c-455c-b29c-1070909e517f" /> |
| <img width="1920" height="1080" alt="No connection" src="https://github.com/user-attachments/assets/3f22f6f8-8d0c-4e31-93fc-bfe62789fe79" /> |
<br/>

Now with a blowtorch you can turn the direction of cables' connections to catwalks.
Should be compatible with existing saves.
### Connection-sides:
- East
- North
- West
- South
- No connection